### PR TITLE
factorysetup: fix OP_BLE_RESULT

### DIFF
--- a/src/factorysetup.c
+++ b/src/factorysetup.c
@@ -325,7 +325,8 @@ static void _api_msg(const uint8_t* input, size_t in_len, uint8_t* output, size_
         break;
     case OP_BLE_RESULT:
         if (memory_get_platform() == MEMORY_PLATFORM_BITBOX02_PLUS) {
-            output[1] = _ble_result;
+            output[2] = _ble_result;
+            out_len++;
         } else {
             result = ERR_UNKNOWN_COMMAND;
         }


### PR DESCRIPTION
output[0] is the command, output[1] is the the error according to `error_code_t`. For sanity, the OP_BLE_RESULT call should just return the ble_error_code_t result var, so we put it into output[2]. output[1] will be 0, meaning fetching the BLE result suceeded, even if that result itself might be a failure.