### PR TITLE
api/device_info: return info about Bluetooth

### DIFF
--- a/messages/bitbox02_system.proto
+++ b/messages/bitbox02_system.proto
@@ -26,6 +26,10 @@ message DeviceInfoRequest {
 }
 
 message DeviceInfoResponse {
+  message Bluetooth {
+    // Hash of the currently active Bluetooth firmware on the device.
+    bytes firmware_hash = 1;
+  }
   string name = 1;
   bool initialized = 2;
   string version = 3;
@@ -33,6 +37,8 @@ message DeviceInfoResponse {
   uint32 monotonic_increments_remaining = 5;
   // From v9.6.0: "ATECC608A" or "ATECC608B".
   string securechip_model = 6;
+  // Only present in Bluetooth-enabled devices.
+  optional Bluetooth bluetooth = 7;
 }
 
 message InsertRemoveSDCardRequest {

--- a/py/bitbox02/CHANGELOG.md
+++ b/py/bitbox02/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add support for regtest (supported from firmware version v9.21.0)
 - btc_sign: allow identifying outputs belonging to different accounts of the same keystore
 - Detect BitBox02 Plus
+- Add Bluetooth info to the device info response
 
 # 6.3.0
 - Allow infering product and version via API call instead of via USB descriptor

--- a/py/bitbox02/bitbox02/bitbox02/bitbox02.py
+++ b/py/bitbox02/bitbox02/bitbox02/bitbox02.py
@@ -175,6 +175,12 @@ class BitBox02(BitBoxCommonAPI):
         }
         if self.version >= semver.VersionInfo(9, 6, 0):
             result["securechip_model"] = response.device_info.securechip_model
+        if response.device_info.bluetooth is not None:
+            result["bluetooth"] = {
+                "firwmare_hash": response.device_info.bluetooth.firmware_hash,
+            }
+        else:
+            result["bluetooth"] = None
 
         return result
 
@@ -1246,7 +1252,11 @@ class BitBox02(BitBoxCommonAPI):
                 print("Sending chunk", chunk_response)
                 request = bluetooth.BluetoothRequest()
                 request.chunk.CopyFrom(
-                    bluetooth.BluetoothChunkRequest(data=firmware[chunk_response.offset:chunk_response.offset+chunk_response.length]),
+                    bluetooth.BluetoothChunkRequest(
+                        data=firmware[
+                            chunk_response.offset : chunk_response.offset + chunk_response.length
+                        ]
+                    ),
                 )
                 response = self._bluetooth_msg_query(request)
             elif response_type == "success":

--- a/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.py
+++ b/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.py
@@ -13,7 +13,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x62itbox02_system.proto\x12\x14shiftcrypto.bitbox02\"\x14\n\x12\x43heckSDCardRequest\"\'\n\x13\x43heckSDCardResponse\x12\x10\n\x08inserted\x18\x01 \x01(\x08\"\x13\n\x11\x44\x65viceInfoRequest\"\xaf\x01\n\x12\x44\x65viceInfoResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0binitialized\x18\x02 \x01(\x08\x12\x0f\n\x07version\x18\x03 \x01(\t\x12#\n\x1bmnemonic_passphrase_enabled\x18\x04 \x01(\x08\x12&\n\x1emonotonic_increments_remaining\x18\x05 \x01(\r\x12\x18\n\x10securechip_model\x18\x06 \x01(\t\"\x9b\x01\n\x19InsertRemoveSDCardRequest\x12L\n\x06\x61\x63tion\x18\x01 \x01(\x0e\x32<.shiftcrypto.bitbox02.InsertRemoveSDCardRequest.SDCardAction\"0\n\x0cSDCardAction\x12\x0f\n\x0bREMOVE_CARD\x10\x00\x12\x0f\n\x0bINSERT_CARD\x10\x01\"\x0e\n\x0cResetRequest\",\n\x18SetDeviceLanguageRequest\x12\x10\n\x08language\x18\x01 \x01(\t\"$\n\x14SetDeviceNameRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"%\n\x12SetPasswordRequest\x12\x0f\n\x07\x65ntropy\x18\x01 \x01(\x0c\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x15\x62itbox02_system.proto\x12\x14shiftcrypto.bitbox02\"\x14\n\x12\x43heckSDCardRequest\"\'\n\x13\x43heckSDCardResponse\x12\x10\n\x08inserted\x18\x01 \x01(\x08\"\x13\n\x11\x44\x65viceInfoRequest\"\xad\x02\n\x12\x44\x65viceInfoResponse\x12\x0c\n\x04name\x18\x01 \x01(\t\x12\x13\n\x0binitialized\x18\x02 \x01(\x08\x12\x0f\n\x07version\x18\x03 \x01(\t\x12#\n\x1bmnemonic_passphrase_enabled\x18\x04 \x01(\x08\x12&\n\x1emonotonic_increments_remaining\x18\x05 \x01(\r\x12\x18\n\x10securechip_model\x18\x06 \x01(\t\x12J\n\tbluetooth\x18\x07 \x01(\x0b\x32\x32.shiftcrypto.bitbox02.DeviceInfoResponse.BluetoothH\x00\x88\x01\x01\x1a\"\n\tBluetooth\x12\x15\n\rfirmware_hash\x18\x01 \x01(\x0c\x42\x0c\n\n_bluetooth\"\x9b\x01\n\x19InsertRemoveSDCardRequest\x12L\n\x06\x61\x63tion\x18\x01 \x01(\x0e\x32<.shiftcrypto.bitbox02.InsertRemoveSDCardRequest.SDCardAction\"0\n\x0cSDCardAction\x12\x0f\n\x0bREMOVE_CARD\x10\x00\x12\x0f\n\x0bINSERT_CARD\x10\x01\"\x0e\n\x0cResetRequest\",\n\x18SetDeviceLanguageRequest\x12\x10\n\x08language\x18\x01 \x01(\t\"$\n\x14SetDeviceNameRequest\x12\x0c\n\x04name\x18\x01 \x01(\t\"%\n\x12SetPasswordRequest\x12\x0f\n\x07\x65ntropy\x18\x01 \x01(\x0c\x62\x06proto3')
 
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'bitbox02_system_pb2', globals())
@@ -27,17 +27,19 @@ if _descriptor._USE_C_DESCRIPTORS == False:
   _DEVICEINFOREQUEST._serialized_start=110
   _DEVICEINFOREQUEST._serialized_end=129
   _DEVICEINFORESPONSE._serialized_start=132
-  _DEVICEINFORESPONSE._serialized_end=307
-  _INSERTREMOVESDCARDREQUEST._serialized_start=310
-  _INSERTREMOVESDCARDREQUEST._serialized_end=465
-  _INSERTREMOVESDCARDREQUEST_SDCARDACTION._serialized_start=417
-  _INSERTREMOVESDCARDREQUEST_SDCARDACTION._serialized_end=465
-  _RESETREQUEST._serialized_start=467
-  _RESETREQUEST._serialized_end=481
-  _SETDEVICELANGUAGEREQUEST._serialized_start=483
-  _SETDEVICELANGUAGEREQUEST._serialized_end=527
-  _SETDEVICENAMEREQUEST._serialized_start=529
-  _SETDEVICENAMEREQUEST._serialized_end=565
-  _SETPASSWORDREQUEST._serialized_start=567
-  _SETPASSWORDREQUEST._serialized_end=604
+  _DEVICEINFORESPONSE._serialized_end=433
+  _DEVICEINFORESPONSE_BLUETOOTH._serialized_start=385
+  _DEVICEINFORESPONSE_BLUETOOTH._serialized_end=419
+  _INSERTREMOVESDCARDREQUEST._serialized_start=436
+  _INSERTREMOVESDCARDREQUEST._serialized_end=591
+  _INSERTREMOVESDCARDREQUEST_SDCARDACTION._serialized_start=543
+  _INSERTREMOVESDCARDREQUEST_SDCARDACTION._serialized_end=591
+  _RESETREQUEST._serialized_start=593
+  _RESETREQUEST._serialized_end=607
+  _SETDEVICELANGUAGEREQUEST._serialized_start=609
+  _SETDEVICELANGUAGEREQUEST._serialized_end=653
+  _SETDEVICENAMEREQUEST._serialized_start=655
+  _SETDEVICENAMEREQUEST._serialized_end=691
+  _SETPASSWORDREQUEST._serialized_start=693
+  _SETPASSWORDREQUEST._serialized_end=730
 # @@protoc_insertion_point(module_scope)

--- a/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.pyi
+++ b/py/bitbox02/bitbox02/communication/generated/bitbox02_system_pb2.pyi
@@ -36,12 +36,25 @@ global___DeviceInfoRequest = DeviceInfoRequest
 
 class DeviceInfoResponse(google.protobuf.message.Message):
     DESCRIPTOR: google.protobuf.descriptor.Descriptor
+    class Bluetooth(google.protobuf.message.Message):
+        DESCRIPTOR: google.protobuf.descriptor.Descriptor
+        FIRMWARE_HASH_FIELD_NUMBER: builtins.int
+        firmware_hash: builtins.bytes
+        """Hash of the currently active Bluetooth firmware on the device."""
+
+        def __init__(self,
+            *,
+            firmware_hash: builtins.bytes = ...,
+            ) -> None: ...
+        def ClearField(self, field_name: typing_extensions.Literal["firmware_hash",b"firmware_hash"]) -> None: ...
+
     NAME_FIELD_NUMBER: builtins.int
     INITIALIZED_FIELD_NUMBER: builtins.int
     VERSION_FIELD_NUMBER: builtins.int
     MNEMONIC_PASSPHRASE_ENABLED_FIELD_NUMBER: builtins.int
     MONOTONIC_INCREMENTS_REMAINING_FIELD_NUMBER: builtins.int
     SECURECHIP_MODEL_FIELD_NUMBER: builtins.int
+    BLUETOOTH_FIELD_NUMBER: builtins.int
     name: typing.Text
     initialized: builtins.bool
     version: typing.Text
@@ -50,6 +63,10 @@ class DeviceInfoResponse(google.protobuf.message.Message):
     securechip_model: typing.Text
     """From v9.6.0: "ATECC608A" or "ATECC608B"."""
 
+    @property
+    def bluetooth(self) -> global___DeviceInfoResponse.Bluetooth:
+        """Only present in Bluetooth-enabled devices."""
+        pass
     def __init__(self,
         *,
         name: typing.Text = ...,
@@ -58,8 +75,11 @@ class DeviceInfoResponse(google.protobuf.message.Message):
         mnemonic_passphrase_enabled: builtins.bool = ...,
         monotonic_increments_remaining: builtins.int = ...,
         securechip_model: typing.Text = ...,
+        bluetooth: typing.Optional[global___DeviceInfoResponse.Bluetooth] = ...,
         ) -> None: ...
-    def ClearField(self, field_name: typing_extensions.Literal["initialized",b"initialized","mnemonic_passphrase_enabled",b"mnemonic_passphrase_enabled","monotonic_increments_remaining",b"monotonic_increments_remaining","name",b"name","securechip_model",b"securechip_model","version",b"version"]) -> None: ...
+    def HasField(self, field_name: typing_extensions.Literal["_bluetooth",b"_bluetooth","bluetooth",b"bluetooth"]) -> builtins.bool: ...
+    def ClearField(self, field_name: typing_extensions.Literal["_bluetooth",b"_bluetooth","bluetooth",b"bluetooth","initialized",b"initialized","mnemonic_passphrase_enabled",b"mnemonic_passphrase_enabled","monotonic_increments_remaining",b"monotonic_increments_remaining","name",b"name","securechip_model",b"securechip_model","version",b"version"]) -> None: ...
+    def WhichOneof(self, oneof_group: typing_extensions.Literal["_bluetooth",b"_bluetooth"]) -> typing.Optional[typing_extensions.Literal["bluetooth"]]: ...
 global___DeviceInfoResponse = DeviceInfoResponse
 
 class InsertRemoveSDCardRequest(google.protobuf.message.Message):

--- a/src/rust/bitbox02-rust/src/hww/api/bluetooth.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/bluetooth.rs
@@ -175,7 +175,10 @@ pub async fn process_api(
     hal: &mut impl crate::hal::Hal,
     request: &Request,
 ) -> Result<Response, Error> {
-    if !matches!(memory::get_platform()?, memory::Platform::BitBox02Plus) {
+    if !matches!(
+        memory::get_platform().map_err(|_| Error::Memory)?,
+        memory::Platform::BitBox02Plus
+    ) {
         return Err(Error::Disabled);
     }
     match request {

--- a/src/rust/bitbox02-rust/src/hww/api/device_info.rs
+++ b/src/rust/bitbox02-rust/src/hww/api/device_info.rs
@@ -20,6 +20,15 @@ use pb::response::Response;
 use bitbox02::{memory, securechip};
 
 pub fn process() -> Result<Response, Error> {
+    let bluetooth = match memory::get_platform().map_err(|_| Error::Memory)? {
+        memory::Platform::BitBox02Plus => {
+            let ble_metadata = memory::get_ble_metadata();
+            Some(pb::device_info_response::Bluetooth {
+                firmware_hash: ble_metadata.allowed_firmware_hash.to_vec(),
+            })
+        }
+        memory::Platform::BitBox02 => None,
+    };
     Ok(Response::DeviceInfo(pb::DeviceInfoResponse {
         name: memory::get_device_name(),
         initialized: memory::is_initialized(),
@@ -31,5 +40,6 @@ pub fn process() -> Result<Response, Error> {
             securechip::Model::ATECC_ATECC608B => "ATECC608B".into(),
             securechip::Model::OPTIGA_TRUST_M_V3 => "OPTIGA_TRUST_M_V3".into(),
         },
+        bluetooth,
     }))
 }

--- a/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
+++ b/src/rust/bitbox02-rust/src/shiftcrypto.bitbox02.rs
@@ -126,6 +126,19 @@ pub struct DeviceInfoResponse {
     /// From v9.6.0: "ATECC608A" or "ATECC608B".
     #[prost(string, tag = "6")]
     pub securechip_model: ::prost::alloc::string::String,
+    /// Only present in Bluetooth-enabled devices.
+    #[prost(message, optional, tag = "7")]
+    pub bluetooth: ::core::option::Option<device_info_response::Bluetooth>,
+}
+/// Nested message and enum types in `DeviceInfoResponse`.
+pub mod device_info_response {
+    #[allow(clippy::derive_partial_eq_without_eq)]
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct Bluetooth {
+        /// Hash of the currently active Bluetooth firmware on the device.
+        #[prost(bytes = "vec", tag = "1")]
+        pub firmware_hash: ::prost::alloc::vec::Vec<u8>,
+    }
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, Copy, PartialEq, ::prost::Message)]


### PR DESCRIPTION
Currently we only know the hash, we will probably add a version string later on too. The host app can use this to decide whether to prompt an upgrade.